### PR TITLE
Refactor for 0.14 with experimental

### DIFF
--- a/examples/example1/main.tf
+++ b/examples/example1/main.tf
@@ -23,97 +23,17 @@ module "rd_job" {
   # node_filter_exclude_precedence = "" # Accepting the module's default
 
   # Module command blocks
-  command = {
-    command_one = {
-      description      = "Command block, index command_one"
-      shell_command    = "echo 'Command block, index command_one'"
-      inline_script    = null
-      script_file      = null
-      script_file_args = null
+  commands = [
+    {
+      description = "command block"
+      jobs = [
+        {
+          name = "job 1 in command block"
+        },
+        {
+          name = "job 2 in command block"
+        }
+      ]
     }
-    command_two = {
-      description      = "Command block, index command_two"
-      shell_command    = null
-      inline_script    = null
-      script_file      = null
-      script_file_args = null
-    }
-    command_three = {
-      description      = "Command block, index command_three"
-      shell_command    = null
-      inline_script    = null
-      script_file      = null
-      script_file_args = null
-    }
-    command_four = {
-      description      = "Command block, index command_four"
-      shell_command    = null
-      inline_script    = null
-      script_file      = null
-      script_file_args = null
-    }
-    command_five = {
-      description      = "Command block, index command_five"
-      shell_command    = null
-      inline_script    = null
-      script_file      = null
-      script_file_args = null
-    }
-  }
-
-  command_job = {
-    command_two = {
-      name              = "command_job-command_two"
-      group_name        = null
-      run_for_each_node = null
-      args              = null
-    }
-    command_three = {
-      name              = "command_job-command_three"
-      group_name        = null
-      run_for_each_node = null
-      args              = null
-    }
-  }
-
-  command_job_nodefilters = {
-    command_three = {
-      excludeprecedence = false
-      filter            = "*.*"
-    }
-  }
-
-  command_node_step_plugin = {
-    command_four = {
-      type   = "command_four - type"
-      config = {}
-    }
-  }
-
-  command_step_plugin = {
-    command_five = {
-      type   = "command_five - type"
-      config = {}
-    }
-  }
-  
-  # Module notification blocks
-  notification = {
-    notification_one = {
-      type = "on_success"
-      webhook_urls = ["http://localhost?index=notification_one"]
-    }
-    notification_two = {
-      type = "email"
-      webhook_urls = null
-    }
-  }
-
-  notification_email = {
-    notification_two = {
-      attach_log = true
-      recipients = ["root@localhost"]
-      subject = "Notification two, email"
-    }
-  }
+  ]
 }

--- a/examples/example1/variables.tf
+++ b/examples/example1/variables.tf
@@ -4,7 +4,7 @@ variable "api_version" {
   default     = null
 
   validation {
-    condition = var.api_version == null || can(regex("[[:digit:]]+", var.api_version))
+    condition     = var.api_version == null || can(regex("[[:digit:]]+", var.api_version))
     error_message = "Variable api_version must be a number, or null and use environment variable RUNDECK_API_VERSION."
   }
 }
@@ -16,7 +16,7 @@ variable "auth_token" {
   default     = null
 
   validation {
-    condition = var.auth_token == null || can(regex("[[:alnum:]]+", var.auth_token))
+    condition     = var.auth_token == null || can(regex("[[:alnum:]]+", var.auth_token))
     error_message = "Variable auth_token must be an alpha-numeric string, or null and use environment variable RUNDECK_AUTH_TOKEN."
   }
 }
@@ -27,7 +27,7 @@ variable "url" {
   default     = null
 
   validation {
-    condition = var.url == null || can(regex("^https?://", var.url))
+    condition     = var.url == null || can(regex("^https?://", var.url))
     error_message = "Variable url must be an alpha-numeric starting with http:// or https://, or null and use environment variable RUNDECK_URL."
   }
 }

--- a/header.txt
+++ b/header.txt
@@ -3,47 +3,4 @@
 
 Terraform rundeck job module.
 
-A Rundeck job is quite complex, and as such its representation in Terraform can
-also be a bit daunting. Beginning with Terraform 0.15.x, we'll have support for
-defaulting values in structured objects, and while experimental in 0.14.x, it
-was thought best to not use experimental features for the time being.
-
-With this in mind, the structure of the job's nested blocks is in a keyed-index
-model.
-
-The following relationships apply:
-
-- A `rundeck_job` can have several command blocks: `{ n | n ∈ ℕ}`
-- A `command {}` block __may__ have a `job {}` block: 0 or 1
-- A `command {}` block __may__ have a `node_step_plugin {}` block: 0 or 1
-- A `command {}` block __may__ have a `step_plugin {}` block: 0 or 1
-- Several `notification {}` blocks __may__ exist: `{ n | n ∈ ℝ }`
-- A `notification {}` block __may__ have several `email {}` blocks: `{ n | n ∈ ℝ }`
-- A `notification {}` block __may__ have several `plugin {}` blocks: `{ n | n ∈ ℝ }`
-
-How this is accomplished in Terraform is via named indexes. Each `command {}`
-block is identified by it's index and must be unique. You can re-use existing
-indexes for nested items, however not for parent items like `command {}` and
-`notification {}`. There are different variables defining the sub-objects and
-their relationship to the parent via their name:
-
-Command block relationships:
-
-- `var.command`
-- `var.command_job`
-- `var.command_job_notification`
-- `var.command_node_step_plugin`
-- `var.command_step_plugin`
-
-Notification block relationships:
-
-- `var.notification`
-- `var.notification_email`
-- `var.notification_plugin`
-
-Indexes of sub-objects must link up to its parent object to populate the
-correct `rundeck_job` `command` or `notification` block element.
-
-Example:
-
-- Please see [examples/example1/main.tf](examples/example1/main.tf)
+NOTE: Terraform experimental feature enabled: [module_variable_optional_attrs](https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes)

--- a/providers.tf
+++ b/providers.tf
@@ -6,6 +6,8 @@
 terraform {
   required_version = "~> 0.14.0"
 
+  experiments = [module_variable_optional_attrs]
+
   required_providers {
     rundeck = {
       version = "~> 0.4.0"

--- a/variables.tf
+++ b/variables.tf
@@ -128,98 +128,69 @@ variable "node_filter_exclude_precedence" {
   default     = false
 }
 
-variable "option" {
+variable "options" {
   type = list(object({
     name                      = string
-    default_value             = string
-    value_choices             = list(string)
-    value_choices_url         = string
-    require_predefined_choice = bool
-    validation_regex          = string
-    description               = string
-    required                  = bool
-    allow_multiple_values     = bool
-    multi-value_delimiter     = string
-    obscure_input             = bool
-    exposed_to_scripts        = bool
+    default_value             = optional(string)
+    value_choices             = optional(list(string))
+    value_choices_url         = optional(string)
+    require_predefined_choice = optional(bool)
+    validation_regex          = optional(string)
+    description               = optional(string)
+    required                  = optional(bool)
+    allow_multiple_values     = optional(bool)
+    multi_value_delimiter     = optional(string)
+    obscure_input             = optional(bool)
+    exposed_to_scripts        = optional(bool)
   }))
   description = "Nested block defining an option a user may set when executing this job. A job may have any number of options."
   default     = []
 }
 
-variable "command" {
-  type = map(object({
-    description      = string
-    shell_command    = string
-    inline_script    = string
-    script_file      = string
-    script_file_args = string
+variable "commands" {
+  type = list(object({
+    description      = optional(string)
+    shell_command    = optional(string)
+    inline_script    = optional(string)
+    script_file      = optional(string)
+    script_file_args = optional(string)
+
+    # job blocks (optional)
+    jobs = optional(list(object({
+      name              = string
+      group_name        = optional(string)
+      run_for_each_node = optional(bool)
+      args              = optional(string)
+      nodefilters       = optional(map(any))
+    })))
+
+    # node_step_plugin and step_plugin blocks (optional)
+    # plugin = (node_step_plugin || step_plugin)
+    steps = optional(list(object({
+      plugin = string
+      type   = string
+      config = optional(map(any))
+    })))
   }))
   description = "Nested block defining one step in the job workflow. A job must have one or more commands."
 }
 
-variable "command_job" {
-  type = map(object({
-    name              = string
-    group_name        = string
-    run_for_each_node = bool
-    args              = string
-  }))
-  description = "A job block for a command."
-  default     = {}
-}
-
-variable "command_job_nodefilters" {
-  type = map(object({
-    excludeprecedence = bool
-    filter            = string
-  }))
-  description = "A nodefilters block for a specific job block"
-  default     = {}
-}
-
-variable "command_node_step_plugin" {
-  type = map(object({
-    type   = string
-    config = map(string)
-  }))
-  description = "A node_step_plugin block for a command."
-  default     = {}
-}
-
-variable "command_step_plugin" {
-  type = map(object({
-    type   = string
-    config = map(string)
-  }))
-  description = "A step block for a command."
-  default     = {}
-}
-
-variable "notification" {
-  type = map(object({
+variable "notifications" {
+  type = list(object({
     type         = string
-    webhook_urls = list(string)
+    webhook_urls = optional(list(string))
+
+    emails = optional(list(object({
+      attach_log = optional(bool)
+      recipients = list(string)
+      subject    = optional(string)
+    })))
+
+    plugins = optional(list(object({
+      type   = string
+      config = map(any)
+    })))
   }))
   description = "Nested block defining notifications on the job workflow."
-  default     = {}
-}
-
-variable "notification_email" {
-  type = map(object({
-    attach_log = bool
-    recipients = list(string)
-    subject    = string
-  }))
-  description = "Email block for a notification"
-  default     = {}
-}
-
-variable "notification_plugin" {
-  type = map(object({
-    type   = string
-    config = map(string)
-  }))
-  description = "Plugin block for a notification"
-  default     = {}
+  default     = []
 }


### PR DESCRIPTION
# Pull Request

## Description
<!-- Describe your changes in detail -->
<!-- Cite ALL GitHub issues -->
- Resolves GH-3
- Resolves GH-7
- Refactor `var.commands` to be representative of a `command` block
- Refactor `var.notifications` to be representative of a `notification` block
- Named indexable vars removed due to primary vars used as base indexes refactoring

Signed-off-by: Brian Menges <mengesb@gmail.com>

## Types of changes
<!--- Put an `x` in **ONE** the boxes. -->
<!--- To fill in a selection, place an `x` in the box like so: [x] -->
<!--- Questions? Don't hesitate to ask. We're here to help! -->
- [ ] PATCH change (a.b.PATCH) - adding configuration or non-breaking fix
- [x] FEATURE change (a.FEATURE.0) - non-breaking change which adds
  functionality
- [ ] MAJOR change (MAJOR.0.0) - fix or feature that would cause existing
  functionality to not work as expected

## Gists

Commands block now a `list(object({})` allowing for a more expressive object

```hcl
  commands = [
    {
      description = "command block"
      jobs = [
        {
          name = "job 1 in command block"
        },
        {
          name = "job 2 in command block"
        }
      ]
    }
  ]
```

Experimental feature: `module_variable_optional_attrs`

Even though we don't use `defaults()`, we allow the `optional()` nature of defined objects or object attributes to be `null` (default behavior when not using `defaults()` to provide a default). The module handles this in the `dynamic` block by testing for null

```hcl
  dynamic "command" {
    for_each = var.commands

    content {
      description   = command.value.description
      shell_command = command.value.shell_command
      inline_script = command.value.inline_script
      script_file   = command.value.inline_script

      dynamic "job" {
        for_each = command.value.jobs

        content {
          name              = job.value.name
          group_name        = job.value.group_name
          run_for_each_node = job.value.run_for_each_node
          args              = job.value.args
          nodefilters       = job.value.nodefilters
        }
      }

      dynamic "node_step_plugin" {
        for_each = command.value.steps == null ? [] : [for j in command.value.steps : { type = j.type, config = j.config } if j.plugin == "node_step_plugin"]

        content {
          type   = node_step_plugin.value.type
          config = node_step_plugin.value.config
        }
      }

      dynamic "step_plugin" {
        for_each = command.value.steps == null ? [] : [for k in command.value.steps : { type = k.type, config = k.config } if k.plugin == "step_plugin"]

        content {
          type   = step_plugin.value.type
          config = step_plugin.value.config
        }
      }
    }
  }
```

This way the resource is provided the correct options only when present, and requirements for the object are enforced in the variable definition.

## Checklist
<!--- Put an `x` in all the boxes that apply. -->
<!--- Questions? Don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (linting).
- [ ] Associated workspace speculative plans pass and/or tests appear correct
- [ ] My change requires a change to the documentation and have been completed
